### PR TITLE
DA lang context fix "hibernation option"

### DIFF
--- a/lang/app/strings/translations_da.properties
+++ b/lang/app/strings/translations_da.properties
@@ -443,5 +443,7 @@ retryAll=Prøv igen alle
 replace=Erstat
 replaceAll=Udskift alle
 copyPassword=copyPassword
-lockVaultOnHibernation=Lås hvælving på computer i dvale
-lockVaultOnHibernationDescription=Når denne funktion er aktiveret, låses boksen automatisk, når computeren sættes i dvale. Når du vågner, skal du indtaste din vault-passphrase igen.
+#custom
+lockVaultOnHibernation=Lås Vault når computeren går i dvale
+#custom
+lockVaultOnHibernationDescription=Når denne funktion er aktiveret, låses Vaulten automatisk, når computeren sættes i dvale. Når du bruger computeren igen, skal du indtaste din vault-adgangsætning igen.


### PR DESCRIPTION
Added the correct text context. It will prob. be changed with time, but for now it's WAY better than "hvælving" = Arch.