### PR TITLE
PL translation fixes and EN source disambiguations

### DIFF
--- a/lang/strings/translations_en.properties
+++ b/lang/strings/translations_en.properties
@@ -40,6 +40,7 @@ selectTypeDescription=Select connection type
 selectShellType=Shell Type
 #context: computer shell program
 selectShellTypeDescription=Select the Type of the Shell Connection
+#context: name of an inanimate or abstract object
 name=Name
 storeIntroTitle=Connection Hub
 storeIntroDescription=Here you can manage all your local and remote shell connections in one place. To start off, you can quickly detect available connections automatically and choose which ones to add.
@@ -1193,6 +1194,7 @@ lockCreationAlertHeader=Create new vault user
 loginAlertTitle=Login required
 loginAlertHeader=Unlock vault to access your personal connections
 vaultUser=Vault user
+#context: dative case
 me=Me
 addUser=Add user ...
 addUserDescription=Create a new user for this vault
@@ -1280,6 +1282,7 @@ serviceProtocolType=Service protocol type
 serviceProtocolTypeDescription=Control how to open the service
 serviceCommand=The command to run once the service is active
 serviceCommandDescription=The placeholder $PORT will be replaced with the actual tunneled local port
+#context: not the measure of importance or personal ethics
 value=Value
 showAdvancedOptions=Show advanced options
 sshAdditionalConfigOptions=Additional config options

--- a/lang/strings/translations_pl.properties
+++ b/lang/strings/translations_pl.properties
@@ -1146,7 +1146,8 @@ lockCreationAlertHeader=Utwórz nowego użytkownika skarbca
 loginAlertTitle=Wymagane logowanie
 loginAlertHeader=Odblokuj skarbiec, aby uzyskać dostęp do połączeń osobistych
 vaultUser=Użytkownik Vault
-me=Ja
+#custom
+me=Mi
 addUser=Dodaj użytkownika ...
 addUserDescription=Utwórz nowego użytkownika dla tego skarbca
 skip=Pomiń


### PR DESCRIPTION
There is some ambiguity in "name", "me", and "value" that impact translations in various languages.

- I assumed "name" is for inanimate objects specifically as in Polish there is a different translation of a person's "name".
- I assumed "me" is in dative case. DE reference is in nominative but DA reference is in dative/accusative. English source "me" is not nominative but ambiguous otherwise.
- I assumed "value" is like a setting instead of an "ethical value" or a price which would be written differently in some languages.
- Fixed Polish to use dative version of "me" instead of nominative. 

Splitting these labels might be necessary if they have difference use cases. I wasn't able to find the use cases.