### PR TITLE
Fix French translations for various strings properties

### DIFF
--- a/lang/strings/translations_fr.properties
+++ b/lang/strings/translations_fr.properties
@@ -209,7 +209,8 @@ print=Imprimer
 whatsNew=Nouveautés de la version $VERSION$ ($DATE$)
 antivirusNoticeTitle=Une note sur les programmes antivirus
 updateChangelogAlertTitle=Changelog
-greetingsAlertTitle=Bienvenue à XPipe
+#custom
+greetingsAlertTitle=Bienvenue sur XPipe
 eula=Contrat de licence de l'utilisateur final
 #custom
 news=Nouveautés
@@ -1141,7 +1142,7 @@ tshNode.displayName=Nœud de téléportation
 tshNode.displayDescription=Se connecter à un nœud de téléportation dans un cluster
 teleportCluster=Cluster
 #custom
-teleportClusterDescription=Le cluster dans lequelle se trouve le nœud
+teleportClusterDescription=Le cluster dans lequel se trouve le nœud
 teleportProxy=Proxy
 teleportProxyDescription=Le serveur proxy utilisé pour se connecter au nœud
 teleportHost=Hôte
@@ -1262,7 +1263,8 @@ isOnlySupported=n'est pris en charge qu'avec au moins une licence $TYPE$
 areOnlySupported=ne sont pris en charge qu'avec au moins une licence $TYPE$
 openApiDocs=Documentation de l'API
 openApiDocsDescription=La documentation de l'API HTTP est disponible en ligne, y compris une spécification OpenAPI .yaml. Tu peux l'ouvrir dans ton navigateur web ou dans ton client HTTP préféré.
-openApiDocsButton=Open docs
+#custom
+openApiDocsButton=Ouvrir la documentation
 pythonApi=API Python
 personalConnection=Cette connexion et tous ses enfants ne sont disponibles que pour ton utilisateur car ils dépendent d'une identité personnelle.
 developerPrintInitFiles=Exécution d'un fichier d'initialisation d'impression
@@ -1318,7 +1320,8 @@ refreshSources=Icônes de rafraîchissement
 refreshSourcesDescription=Mets à jour toutes les icônes à partir des sources disponibles
 addDirectoryIconSource=Ajouter une source de répertoire ...
 addDirectoryIconSourceDescription=Ajouter des icônes à partir d'un répertoire local
-addGitIconSource=Ajouter git source ...
+#custom
+addGitIconSource=Ajouter une source git ...
 addGitIconSourceDescription=Ajouter des icônes situées dans un dépôt git distant
 repositoryUrl=URL du dépôt Git
 iconDirectory=Répertoire d'icônes
@@ -1334,7 +1337,8 @@ iconSourceDeletionTitle=Supprimer la source de l'icône
 iconSourceDeletionContent=Veux-tu supprimer cette source d'icônes et toutes les icônes qui y sont associées ?
 refreshIcons=Icônes de rafraîchissement
 refreshIconsDescription=Récupération, rendu et mise en cache de toutes les icônes $COUNT$ disponibles dans des fichiers .png. Cela peut prendre un certain temps...
-vaultUserLegacy=Utilisateur de la chambre forte (mode de compatibilité héritée limité)
+#custom
+vaultUserLegacy=Utilisateur du coffre-fort (mode de compatibilité héritée limité)
 upgradeInstructions=Instructions de mise à niveau
 externalLaunchTitle=Demande de lancement externe
 externalLaunchContent=Un terminal externe a demandé à lancer une connexion shell. Veux-tu autoriser le lancement de connexions shell depuis l'extérieur de XPipe ?
@@ -1348,7 +1352,8 @@ connectionsSelected=$NUMBER$ connexions sélectionnées
 addConnections=Nouveau
 browseDirectory=Répertoire de navigation
 openTerminal=Terminal ouvert
-documentation=Docs
+#custom
+documentation=Documentation
 report=Signaler une erreur
 keePassXcNotAssociated=Lien KeePassXC
 keePassXcNotAssociatedDescription=XPipe n'est pas associé à ta base de données KeePassXC locale. Clique ci-dessous pour associer XPipe à la base de données KeePassXC afin qu'il puisse interroger les mots de passe.
@@ -1407,7 +1412,8 @@ restricted=Restreint
 disableSshPinCaching=Désactiver la mise en cache du code PIN SSH
 disableSshPinCachingDescription=XPipe met automatiquement en cache tous les codes PIN qui ont été saisis pour une clé lors de l'utilisation d'une forme d'authentification basée sur le matériel.\n\nSi tu désactives cette fonction, tu devras ressaisir le code PIN à chaque tentative de connexion.
 gitSyncRestart=Redémarre pour synchroniser les changements git à distance
-enpassVaultFile=Fichier voûte
+#custom
+enpassVaultFile=Fichier du coffre-fort
 enpassVaultFileDescription=Le fichier local du coffre-fort Enpass.
 flat=Plat
 recursive=Récursif


### PR DESCRIPTION
Updates French translations in the `translations_fr.properties` file.

* Corrected phrasing in `teleportClusterDescription` to fix a grammatical error ("lequelle" → "lequel").
* Updated `vaultUserLegacy` to use "coffre-fort" instead of "chambre forte" for better terminology consistency.
* Changed `enpassVaultFile` to "Fichier du coffre-fort" for improved clarity.
* Replaced "Docs" with "Documentation" in `documentation` for better alignment with other terms.
* Updated `openApiDocsButton` from "Open docs" to "Ouvrir la documentation" to provide a localized French translation.
* Refined the phrasing in `addGitIconSource` to "Ajouter une source git ..." for consistency with other similar strings.