### PR TITLE
Set comparator for sizeCol to compare the Long value of the size.

### DIFF
--- a/app/src/main/java/io/xpipe/app/browser/file/BrowserFileListComp.java
+++ b/app/src/main/java/io/xpipe/app/browser/file/BrowserFileListComp.java
@@ -74,6 +74,19 @@ public final class BrowserFileListComp extends SimpleComp {
         sizeCol.textProperty().bind(AppI18n.observable("size"));
         sizeCol.setCellValueFactory(param -> new ReadOnlyStringWrapper(
                 param.getValue().getRawFileEntry().resolved().getSize()));
+        sizeCol.setComparator((size1, size2) -> {
+            if (size1 == null && size2 == null) return 0;
+            if (size1 == null) return -1;
+            if (size2 == null) return 1;
+
+            try {
+                long long1 = Long.parseLong(size1);
+                long long2 = Long.parseLong(size2);
+            return Long.compare(long1, long2);
+            } catch (NumberFormatException e) {
+                return size1.compareTo(size2);
+            }
+        });
         sizeCol.setCellFactory(col -> new FileSizeCell());
         sizeCol.setResizable(false);
         sizeCol.setPrefWidth(120);


### PR DESCRIPTION
1. Fixes #577 
2. Tried to minimize change impact by only setting the comparator of the `sizeCol` `TableColumn`
3. Checks for null values in case it is a directory and correctly puts the directory on top.
4. If we fail to parse the Long from the size string we fallback to string compare.
5. All the tests are passing. 
6. Tested in the App on some heavy system folders. 