### PR TITLE
Fix beacon shell session cache concurrency and reuse

### DIFF
--- a/app/src/main/java/io/xpipe/app/beacon/impl/ShellStopExchangeImpl.java
+++ b/app/src/main/java/io/xpipe/app/beacon/impl/ShellStopExchangeImpl.java
@@ -13,7 +13,7 @@ public class ShellStopExchangeImpl extends ShellStopExchange {
     public Object handle(HttpExchange exchange, Request msg) {
         var e = AppBeaconServer.get().getCache().getShellSession(msg.getConnection());
         e.getControl().close();
-        AppBeaconServer.get().getCache().getShellSessions().remove(e);
+        AppBeaconServer.get().getCache().removeShellSession(msg.getConnection());
         return Response.builder().build();
     }
 }


### PR DESCRIPTION
## What
- Make beacon shell session cache concurrent and single-creation
- Avoid double-starting shell controls
- Reuse AppBeaconCache in ShellStartExchangeImpl and simplify stop logic

## Why
- Prevent duplicate shell session creation under concurrent requests
- Avoid redundant `start()` calls on existing sessions
- Improve stability for MCP/HTTP access paths

## Changes
- Use ConcurrentHashMap + computeIfAbsent keyed by entry UUID
- Initialize control once (setNonInteractive + start) in cache creation path
- ShellStartExchangeImpl now reuses AppBeaconCache.getOrStart
- ShellStopExchangeImpl removes by UUID

## Testing
- Not run (requires local XPipe installation + JDK 25)
