### PR TITLE
terminal: pass title to ptyxis tabs/windows

### DIFF
--- a/app/src/main/java/io/xpipe/app/terminal/PtyxisTerminalType.java
+++ b/app/src/main/java/io/xpipe/app/terminal/PtyxisTerminalType.java
@@ -31,6 +31,8 @@ public class PtyxisTerminalType implements ExternalApplicationType.LinuxApplicat
         var toExecute = CommandBuilder.of()
                 .addIf(configuration.isPreferTabs(), "--tab")
                 .addIf(!configuration.isPreferTabs(), "--new-window")
+                .add("--title")
+                .addQuoted(configuration.getColoredTitle())
                 .add("--")
                 .add(configuration.single().getDialectLaunchCommand());
         launch(toExecute);


### PR DESCRIPTION
## Summary
- add `--title` when launching Ptyxis from XPipe
- pass XPipe's computed connection title via `configuration.getColoredTitle()`
- keep existing tab/window behavior (`--tab` / `--new-window`) unchanged

## Why
Ptyxis supports `--title` for new tabs/windows, but XPipe's Ptyxis launcher did not pass it. This caused server/connection names not to appear in Ptyxis tab titles.

## Validation
- verified locally that Ptyxis accepts custom titles with:
  - `ptyxis --new-window --title "..." -- bash -lc 'sleep 1'`
  - `ptyxis --tab --title "..." -- bash -lc 'sleep 1'`
