### PR TITLE
Fix Windows Terminal selection being reset to uninstalled Warp on restart

### DIFF
--- a/app/src/main/java/io/xpipe/app/terminal/WarpTerminalType.java
+++ b/app/src/main/java/io/xpipe/app/terminal/WarpTerminalType.java
@@ -9,6 +9,7 @@ import io.xpipe.app.webtop.WebtopApp;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 public interface WarpTerminalType extends ExternalTerminalType, TrackableTerminalType {
@@ -57,7 +58,20 @@ public interface WarpTerminalType extends ExternalTerminalType, TrackableTermina
 
         @Override
         public boolean isAvailable() {
-            return WindowsRegistry.local().keyExists(WindowsRegistry.HKEY_CURRENT_USER, "Software\\Classes\\warp");
+            // The uninstaller leaves the protocol handler key behind
+            var command = WindowsRegistry.local()
+                    .readStringValueIfPresent(
+                            WindowsRegistry.HKEY_CURRENT_USER, "Software\\Classes\\warp\\shell\\open\\command", null);
+            if (command.isEmpty()) {
+                return false;
+            }
+
+            try {
+                var split = command.get().split("\"");
+                return split.length > 1 && Files.exists(Path.of(split[1]));
+            } catch (InvalidPathException ignored) {
+                return false;
+            }
         }
 
         @Override

--- a/app/src/main/java/io/xpipe/app/terminal/WindowsTerminalType.java
+++ b/app/src/main/java/io/xpipe/app/terminal/WindowsTerminalType.java
@@ -182,6 +182,12 @@ public interface WindowsTerminalType extends ExternalTerminalType, TrackableTerm
         }
 
         @Override
+        public boolean isAvailable() {
+            // The executable is a weird link
+            return Files.exists(getPath().getParent()) || super.isAvailable();
+        }
+
+        @Override
         public void launch(TerminalLaunchConfiguration configuration) throws Exception {
             checkProfile();
             try (var sc = LocalShell.getShell().start()) {


### PR DESCRIPTION
## What
- `WindowsTerminalType.Standard` now also detects the installation directory instead of relying only on a PATH lookup
- `WarpTerminalType.Windows` now verifies the registered executable exists instead of only checking that a registry key is present

## Why
Selecting Windows Terminal does not survive a restart — XPipe silently switches back to Warp, even after Warp has been uninstalled. Two defects combine:

1. `Standard` inherits `PathApplication#isAvailable`, which only runs `WHERE "wt.exe"`. `wt.exe` is an MSIX app execution alias living in `%LOCALAPPDATA%\Microsoft\WindowsApps` (user PATH), so the lookup fails whenever the process environment lacks an up-to-date user PATH. From a log where this happened:

   ```
   command=WHERE "mstsc.exe"   exitCode=0   (System32, machine PATH)
   command=WHERE "wt.exe"      exitCode=1   (WindowsApps, user PATH)
   ```

   `Preview`, `Canary` and `Intelligent` already use `Files.exists` and are unaffected — `Standard` was the odd one out.

2. Warp's uninstaller leaves `HKCU\Software\Classes\warp` behind, so `isAvailable()` kept returning true while the key pointed at a path that no longer exists.

`determineDefault` then finds the selection unavailable (1) and scans `WINDOWS_TERMINALS`, landing on Warp (2).

## Changes
- Check `Files.exists(getPath().getParent())` first, falling back to the PATH lookup. The parent directory is used because `Files.exists` returns false on the alias file itself — same as the existing three classes.
- Read `shell\open\command` and verify the executable, guarding against `InvalidPathException`.

## Testing
- Reproduced and verified on Windows 11, Windows Terminal 1.24 installed, Warp uninstalled
- `gradlew :app:compileJava` and `:app:spotlessCheck` pass

Related: #279 is the macOS counterpart of the Warp half.
